### PR TITLE
Add Next.js docs reading instruction to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,10 @@ Copy `.env.example` for required Spotify OAuth credentials. Server-only env vars
 - Strict TypeScript (`noEmit: true`)
 - Remote images from `i.scdn.co` and `mosaic.scdn.co` are configured in `next.config.ts`
 
+## Next.js Docs
+
+Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+
 ## Workflow
 
 - Do not use preview tools for testing unless explicitly asked. The user will handle testing themselves.


### PR DESCRIPTION
Mirrors the AGENTS.md directive to always read relevant docs from `node_modules/next/dist/docs/` before any Next.js work, now directly in CLAUDE.md as well.