### PR TITLE
Use Inter for artist/track names in list views

### DIFF
--- a/client/components/history/HistoryScreen.tsx
+++ b/client/components/history/HistoryScreen.tsx
@@ -164,7 +164,7 @@ export function HistoryScreen() {
                           )}
                         </div>
                         <div className="min-w-0">
-                          <p className="font-bold text-on-surface tracking-tight truncate group-hover:text-primary transition-colors">
+                          <p className="font-bold text-on-surface tracking-tight truncate group-hover:text-primary transition-colors font-headline">
                             {item.track.name}
                           </p>
                           <p className="text-xs text-on-surface-variant mt-0.5 truncate">

--- a/client/components/top/ArtistGrid.tsx
+++ b/client/components/top/ArtistGrid.tsx
@@ -29,7 +29,7 @@ export function ArtistGrid({ artists }: { artists: SpotifyArtist[] }) {
           </div>
           <div className="flex-grow min-w-0 border-b border-divider pb-4 group-hover:border-primary transition-colors duration-300">
             <div className="flex justify-between items-start mb-1">
-              <h4 className="text-lg font-bold truncate text-on-surface group-hover:text-primary transition-colors">
+              <h4 className="text-lg font-bold truncate text-on-surface group-hover:text-primary transition-colors font-headline">
                 {artist.name}
               </h4>
               <ArrowUpRight className="size-4 text-outline-variant group-hover:text-primary transition-colors flex-shrink-0 ml-2" />

--- a/client/components/top/TrackTable.tsx
+++ b/client/components/top/TrackTable.tsx
@@ -36,7 +36,7 @@ export function TrackTable({ tracks }: { tracks: SpotifyTrack[] }) {
               </div>
             )}
             <div className="min-w-0">
-              <h4 className="font-bold text-sm tracking-tight text-on-surface truncate">
+              <h4 className="font-bold text-sm tracking-tight text-on-surface truncate font-headline">
                 {track.name}
               </h4>
               <p className="text-xs text-on-surface-variant truncate">


### PR DESCRIPTION
Apply `font-headline` (Inter) to artist names in ArtistGrid, track names in TrackTable, and track names in HistoryScreen. Body text remains Space Grotesk by default.