### PR TITLE
Fix cursor pointer on date group jump buttons in history page

### DIFF
--- a/client/components/history/HistoryScreen.tsx
+++ b/client/components/history/HistoryScreen.tsx
@@ -105,7 +105,7 @@ export function HistoryScreen() {
                   .querySelector(day.href)
                   ?.scrollIntoView({ behavior: "smooth" })
               }
-              className="font-label text-[10px] uppercase tracking-widest text-on-surface-variant hover:text-primary transition-colors"
+              className="font-label text-[10px] uppercase tracking-widest text-on-surface-variant hover:text-primary transition-colors cursor-pointer"
             >
               {day.label}
             </button>


### PR DESCRIPTION
## Summary
- Add `cursor-pointer` to the date group jump buttons (TODAY, YESTERDAY, etc.) in the history page so the pointer cursor shows on hover

## Test plan
- [ ] Visit the history page
- [ ] Hover over the date group labels (TODAY, YESTERDAY, etc.) in the top navigation area
- [ ] Confirm cursor changes to a pointer on hover

https://claude.ai/code/session_013kcFLrVcBrCDZM6i1tVU8h