### PR TITLE
Fix Export tooltip position when sidebar is collapsed

### DIFF
--- a/client/components/app-shell/DesktopSidebar.tsx
+++ b/client/components/app-shell/DesktopSidebar.tsx
@@ -128,42 +128,42 @@ export function DesktopSidebar({
 
         {/* Footer */}
         <div className="mt-auto pt-8 pb-8 border-t border-divider px-6 w-64 shrink-0">
-          <SidebarTooltip
-            enabled={showTooltips}
-            content="Export Data — Coming Soon"
-          >
-            <div className="relative overflow-hidden">
-              <Button
-                variant="secondary"
-                disabled
-                subtitle="Coming Soon"
-                className="w-full shrink-0 transition-[opacity,visibility] duration-300"
-                style={
-                  collapsed
-                    ? {
-                        opacity: 0,
-                        visibility: "hidden",
-                        transitionDelay: "0ms, 300ms",
-                      }
-                    : {
-                        opacity: 1,
-                        visibility: "visible",
-                        transitionDelay: "0ms, 0ms",
-                      }
-                }
-              >
-                Export Data
-              </Button>
+          <div className="relative overflow-hidden">
+            <Button
+              variant="secondary"
+              disabled
+              subtitle="Coming Soon"
+              className="w-full shrink-0 transition-[opacity,visibility] duration-300"
+              style={
+                collapsed
+                  ? {
+                      opacity: 0,
+                      visibility: "hidden",
+                      transitionDelay: "0ms, 300ms",
+                    }
+                  : {
+                      opacity: 1,
+                      visibility: "visible",
+                      transitionDelay: "0ms, 0ms",
+                    }
+              }
+            >
+              Export Data
+            </Button>
+            <SidebarTooltip
+              enabled={showTooltips}
+              content="Export Data — Coming Soon"
+            >
               <div
                 className={cn(
-                  "absolute inset-0 flex items-center transition-opacity duration-300",
+                  "absolute inset-y-0 left-0 flex items-center transition-opacity duration-300",
                   collapsed ? "opacity-50" : "opacity-0 pointer-events-none",
                 )}
               >
                 <Download className="size-[18px] flex-shrink-0 text-on-surface-variant" />
               </div>
-            </div>
-          </SidebarTooltip>
+            </SidebarTooltip>
+          </div>
         </div>
       </aside>
     </TooltipProvider>

--- a/client/components/history/HistoryScreen.tsx
+++ b/client/components/history/HistoryScreen.tsx
@@ -105,7 +105,7 @@ export function HistoryScreen() {
                   .querySelector(day.href)
                   ?.scrollIntoView({ behavior: "smooth" })
               }
-              className="font-label text-[10px] uppercase tracking-widest text-on-surface-variant hover:text-primary transition-colors"
+              className="font-label text-[10px] uppercase tracking-widest text-on-surface-variant hover:text-primary transition-colors cursor-pointer"
             >
               {day.label}
             </button>


### PR DESCRIPTION
## Summary
- Move `SidebarTooltip` to wrap only the Download icon instead of the full-width container
- Change `inset-0` to `inset-y-0 left-0` on the icon div so the tooltip trigger is icon-sized
- Prevents the tooltip from appearing far to the right when the sidebar is collapsed

## Test plan
- [ ] Collapse the desktop sidebar
- [ ] Hover over the Export/Download icon at the bottom
- [ ] Confirm the tooltip appears directly to the right of the icon, not far across the screen

https://claude.ai/code/session_013kcFLrVcBrCDZM6i1tVU8h