### PR TITLE
Fix Export tooltip to appear at sidebar edge like nav items

### DIFF
--- a/client/components/app-shell/DesktopSidebar.tsx
+++ b/client/components/app-shell/DesktopSidebar.tsx
@@ -127,7 +127,7 @@ export function DesktopSidebar({
         </nav>
 
         {/* Footer */}
-        <div className="mt-auto pt-8 pb-8 border-t border-divider px-6 w-64 shrink-0">
+        <div className="mt-auto pt-8 pb-8 border-t border-divider px-6 shrink-0">
           <div className="relative overflow-hidden">
             <Button
               variant="secondary"
@@ -156,7 +156,7 @@ export function DesktopSidebar({
             >
               <div
                 className={cn(
-                  "absolute inset-y-0 left-0 flex items-center transition-opacity duration-300",
+                  "absolute inset-0 flex items-center transition-opacity duration-300",
                   collapsed ? "opacity-50" : "opacity-0 pointer-events-none",
                 )}
               >


### PR DESCRIPTION
## Summary
- Remove `w-64` from the footer div so it follows the sidebar's animated width instead of being fixed at 256px
- Restore `inset-0` on the icon div so the tooltip trigger spans the full sidebar width, anchoring the tooltip to the sidebar's right edge — consistent with navigation item tooltips

## Test plan
- [ ] Collapse the desktop sidebar
- [ ] Hover over the Download icon at the bottom
- [ ] Confirm the tooltip appears at the right edge of the sidebar, matching the nav item tooltips

https://claude.ai/code/session_013kcFLrVcBrCDZM6i1tVU8h