### PR TITLE
fix: increase mobile navbar touch targets for better usability

### DIFF
--- a/client/components/app-shell/MobileTabBar.tsx
+++ b/client/components/app-shell/MobileTabBar.tsx
@@ -8,7 +8,7 @@ interface MobileTabBarProps {
 
 export function MobileTabBar({ pathname }: MobileTabBarProps) {
   return (
-    <nav className="fixed bottom-0 left-0 w-full lg:hidden flex justify-around items-center py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] px-2 bg-surface-container-lowest z-50 border-t border-divider after:absolute after:left-0 after:top-full after:w-full after:h-12 after:bg-surface-container-lowest">
+    <nav className="fixed bottom-0 left-0 w-full lg:hidden flex justify-around items-stretch pb-[env(safe-area-inset-bottom)] px-1 bg-surface-container-lowest z-50 border-t border-divider after:absolute after:left-0 after:top-full after:w-full after:h-12 after:bg-surface-container-lowest">
       {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
         const isActive = pathname.startsWith(href);
         return (
@@ -16,11 +16,11 @@ export function MobileTabBar({ pathname }: MobileTabBarProps) {
             key={href}
             href={href}
             className={cn(
-              "flex flex-col items-center justify-center gap-1 transition-all",
+              "flex flex-1 flex-col items-center justify-center gap-1 py-3 px-2 min-h-[56px] transition-all",
               isActive ? "text-primary" : "text-on-surface-variant",
             )}
           >
-            <Icon className="size-5" />
+            <Icon className="size-6" />
             <span className="font-label text-[10px] uppercase tracking-widest">
               {label}
             </span>

--- a/client/components/auth/LogoutButton.tsx
+++ b/client/components/auth/LogoutButton.tsx
@@ -16,7 +16,7 @@ export function LogoutButton() {
 
   return (
     <button
-      className="text-on-surface-variant hover:text-primary transition-colors disabled:opacity-50 cursor-pointer hover:cursor-pointer"
+      className="text-on-surface-variant hover:text-primary transition-colors disabled:opacity-50 cursor-pointer hover:cursor-pointer p-2 min-h-[44px] min-w-[44px] flex items-center justify-center"
       disabled={isMutating}
       onClick={handleLogout}
       type="button"

--- a/client/components/theme/ThemeToggle.tsx
+++ b/client/components/theme/ThemeToggle.tsx
@@ -14,7 +14,7 @@ export function ThemeToggle() {
           ? "Switch to light mode"
           : "Switch to dark mode"
       }
-      className="text-on-surface-variant cursor-pointer hover:text-primary transition-colors"
+      className="text-on-surface-variant cursor-pointer hover:text-primary transition-colors p-2 min-h-[44px] min-w-[44px] flex items-center justify-center"
       onClick={toggleTheme}
       type="button"
     >


### PR DESCRIPTION
## Summary

- **MobileTabBar**: Each nav link now spans `flex-1` with `min-h-[56px]` and `py-3 px-2` padding — the full cell is tappable, not just the icon and label text. Icon size bumped from 20px → 24px.
- **ThemeToggle / LogoutButton**: Added `p-2 min-h-[44px] min-w-[44px]` so header icon buttons meet the 44px minimum touch target (WCAG / Apple HIG).

## Test plan

- [ ] Open the dashboard on a mobile device or DevTools mobile emulator
- [ ] Verify all 4 bottom tab bar items are easy to tap across their full width
- [ ] Verify the theme toggle and logout button in the top header have a comfortable tap area
- [ ] Confirm layout looks correct in both light and dark mode

https://claude.ai/code/session_011gj7dfV5JLDRiRYUQE1aBC