### PR TITLE
Fix mobile tab bar swallowing taps between nav items

### DIFF
--- a/client/components/app-shell/MobileTabBar.tsx
+++ b/client/components/app-shell/MobileTabBar.tsx
@@ -1,12 +1,17 @@
 import Link from "next/link";
 import { cn } from "@/client/lib/utils";
 import { NAV_ITEMS } from "./nav-config";
+import type { MouseEvent } from "react";
 
 interface MobileTabBarProps {
   pathname: string;
 }
 
 export function MobileTabBar({ pathname }: MobileTabBarProps) {
+  const handleTap = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.currentTarget.blur();
+  };
+
   return (
     <nav className="fixed bottom-0 left-0 w-full lg:hidden flex justify-around items-stretch pb-[env(safe-area-inset-bottom)] px-1 bg-surface-container-lowest z-50 border-t border-divider after:absolute after:left-0 after:top-full after:w-full after:h-12 after:bg-surface-container-lowest">
       {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
@@ -16,8 +21,9 @@ export function MobileTabBar({ pathname }: MobileTabBarProps) {
             key={href}
             href={href}
             prefetch={true}
+            onClick={handleTap}
             className={cn(
-              "flex flex-1 flex-col items-center justify-center gap-1 py-3 px-2 min-h-[56px] touch-manipulation select-none transition-colors active:opacity-60",
+              "flex flex-1 flex-col items-center justify-center gap-1 py-3 px-2 min-h-[56px] touch-manipulation select-none transition-colors [-webkit-tap-highlight-color:transparent] active:opacity-60 focus:outline-none",
               isActive ? "text-primary" : "text-on-surface-variant",
             )}
           >


### PR DESCRIPTION
## Summary
- Blur tab links immediately on tap via `onClick` handler — prevents the focused link from intercepting subsequent taps on sibling nav items
- Add `focus:outline-none` to remove visible focus ring on mobile
- Add `-webkit-tap-highlight-color: transparent` to prevent Safari's default tap overlay from interfering with touch targets

Follow-up to #15. That fix addressed the initial double-tap-to-zoom delay; this fixes the remaining issue where tapping between different nav tabs required multiple attempts because the previously tapped link held focus.

## Test plan
- [ ] On mobile, tap a nav tab (e.g. Artists), then immediately tap a different tab (e.g. Tracks) — should navigate on the first tap
- [ ] Rapidly tap between all four tabs — each should respond on first tap
- [ ] Verify active tab still shows visual feedback (opacity change on press, color on active)

https://claude.ai/code/session_01GUamFUEhwFXmoMUxTrvdyD