### PR TITLE
Clean up mobile tab bar: restore original height, revert viewport hack

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 import { Inter, Space_Grotesk } from "next/font/google";
 import { ThemeScript } from "@/client/components/theme/ThemeScript";
 import "./globals.css";
@@ -12,13 +12,6 @@ const spaceGrotesk = Space_Grotesk({
   subsets: ["latin"],
   variable: "--font-space-grotesk",
 });
-
-export const viewport: Viewport = {
-  width: "device-width",
-  initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
-};
 
 export const metadata: Metadata = {
   title: "Statify",

--- a/client/components/app-shell/MobileTabBar.tsx
+++ b/client/components/app-shell/MobileTabBar.tsx
@@ -1,17 +1,12 @@
 import Link from "next/link";
 import { cn } from "@/client/lib/utils";
 import { NAV_ITEMS } from "./nav-config";
-import type { MouseEvent } from "react";
 
 interface MobileTabBarProps {
   pathname: string;
 }
 
 export function MobileTabBar({ pathname }: MobileTabBarProps) {
-  const handleTap = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.currentTarget.blur();
-  };
-
   return (
     <nav className="fixed bottom-0 left-0 w-full lg:hidden flex justify-around items-center py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] px-2 bg-surface-container-lowest z-50 border-t border-divider after:absolute after:left-0 after:top-full after:w-full after:h-12 after:bg-surface-container-lowest after:pointer-events-none">
       {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
@@ -20,15 +15,13 @@ export function MobileTabBar({ pathname }: MobileTabBarProps) {
           <Link
             key={href}
             href={href}
-            prefetch={true}
-            onClick={handleTap}
             className={cn(
-              "flex flex-1 flex-col items-center justify-center gap-1 py-3 px-2 min-h-[56px] touch-manipulation select-none transition-colors [-webkit-tap-highlight-color:transparent] active:opacity-60 focus:outline-none",
+              "flex flex-col items-center justify-center gap-1 touch-manipulation transition-colors",
               isActive ? "text-primary" : "text-on-surface-variant",
             )}
           >
-            <Icon className="size-6 pointer-events-none" />
-            <span className="font-label text-[10px] uppercase tracking-widest pointer-events-none">
+            <Icon className="size-5" />
+            <span className="font-label text-[10px] uppercase tracking-widest">
               {label}
             </span>
           </Link>


### PR DESCRIPTION
## Summary
- Restore original slim tab bar height (`size-5` icons, no `min-h-[56px]`, no extra padding/flex-1)
- Remove bloated touch workarounds (blur handler, select-none, webkit-tap-highlight, focus:outline-none, active:opacity-60) that didn't fix the core issue
- Revert `maximumScale: 1, userScalable: false` viewport override — it disabled pinch-to-zoom which is an accessibility concern
- Keep only the useful changes: `touch-manipulation`, `transition-colors`, `after:pointer-events-none`

The real tap responsiveness issue is inherent to Next.js router navigation vs client-side conditional rendering (like YouTube uses). The loading.tsx Suspense boundaries from #17 help the most.

## Test plan
- [ ] Verify mobile tab bar is back to its original slim height
- [ ] Verify pinch-to-zoom works again on mobile
- [ ] Verify tab navigation still works

https://claude.ai/code/session_01GUamFUEhwFXmoMUxTrvdyD