### PR TITLE
Fix 404 footer mobile overlap + add Privacy/Terms/API links to error pages

### DIFF
--- a/app/auth-error/page.tsx
+++ b/app/auth-error/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { ArrowLeft, Lock } from "lucide-react";
-import { Logo } from "@/client/components/ui/logo";
+import { ErrorPageFooter } from "@/client/components/app-shell/ErrorPageFooter";
 
 export const metadata = {
   title: "Authentication Error — Statify",
@@ -125,9 +125,7 @@ export default async function AuthErrorPage({
         </div>
       </main>
 
-      <footer className="relative z-10 w-full border-t border-divider px-6 lg:px-12 py-4 flex items-center justify-center">
-        <Logo />
-      </footer>
+      <ErrorPageFooter />
     </div>
   );
 }

--- a/app/auth-error/page.tsx
+++ b/app/auth-error/page.tsx
@@ -55,73 +55,73 @@ export default async function AuthErrorPage({
 
       <main className="relative z-10 flex-1 flex items-center justify-center px-6 lg:px-16 py-16">
         <div className="w-full max-w-2xl text-center">
-        {isClosedBeta ? (
-          <>
-            <div className="inline-flex items-center gap-2 ghost-border bg-white/5 px-4 py-2 mb-8">
-              <Lock className="size-3 text-primary" />
-              <span className="font-label text-[10px] uppercase tracking-[0.2em] text-primary">
-                Invite Only
+          {isClosedBeta ? (
+            <>
+              <div className="inline-flex items-center gap-2 ghost-border bg-white/5 px-4 py-2 mb-8">
+                <Lock className="size-3 text-primary" />
+                <span className="font-label text-[10px] uppercase tracking-[0.2em] text-primary">
+                  Invite Only
+                </span>
+              </div>
+
+              <h1 className="text-5xl sm:text-7xl lg:text-8xl font-extrabold leading-none tracking-tighter text-on-surface font-headline mb-8">
+                {title}
+              </h1>
+
+              <p className="text-on-surface-variant text-lg leading-relaxed max-w-lg mx-auto mb-6">
+                {description}
+              </p>
+
+              <p className="text-on-surface-variant/60 text-sm leading-relaxed max-w-md mx-auto mb-12">
+                Want access? Reach out to the administrator with your Spotify
+                email so it can be added to the allow list.
+              </p>
+
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+                <Link
+                  href="/"
+                  className="inline-flex items-center gap-3 bg-primary text-on-primary px-8 py-4 font-headline font-bold text-sm tracking-wide transition-all active:scale-95"
+                >
+                  <ArrowLeft className="size-4" />
+                  BACK TO HOME
+                </Link>
+              </div>
+            </>
+          ) : (
+            <>
+              <span className="font-label text-[10px] uppercase tracking-[0.2em] text-error block mb-6">
+                Authentication Error
               </span>
-            </div>
 
-            <h1 className="text-5xl sm:text-7xl lg:text-8xl font-extrabold leading-none tracking-tighter text-on-surface font-headline mb-8">
-              {title}
-            </h1>
+              <h1 className="text-5xl sm:text-7xl lg:text-8xl font-extrabold leading-none tracking-tighter text-on-surface font-headline mb-8">
+                {title}
+              </h1>
 
-            <p className="text-on-surface-variant text-lg leading-relaxed max-w-lg mx-auto mb-6">
-              {description}
-            </p>
+              <p className="text-on-surface-variant text-lg leading-relaxed max-w-lg mx-auto mb-12">
+                {description}
+              </p>
 
-            <p className="text-on-surface-variant/60 text-sm leading-relaxed max-w-md mx-auto mb-12">
-              Want access? Reach out to the administrator with your Spotify
-              email so it can be added to the allow list.
-            </p>
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+                <Link
+                  href="/api/auth/login"
+                  className="inline-flex items-center gap-3 bg-primary text-on-primary px-8 py-4 font-headline font-bold text-sm tracking-wide transition-all active:scale-95"
+                >
+                  TRY AGAIN
+                </Link>
+                <Link
+                  href="/"
+                  className="inline-flex items-center gap-3 ghost-border bg-white/5 hover:bg-white/10 text-on-surface px-8 py-4 font-headline font-bold text-sm tracking-wide transition-all active:scale-95"
+                >
+                  <ArrowLeft className="size-4" />
+                  BACK TO HOME
+                </Link>
+              </div>
 
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-              <Link
-                href="/"
-                className="inline-flex items-center gap-3 bg-primary text-on-primary px-8 py-4 font-headline font-bold text-sm tracking-wide transition-all active:scale-95"
-              >
-                <ArrowLeft className="size-4" />
-                BACK TO HOME
-              </Link>
-            </div>
-          </>
-        ) : (
-          <>
-            <span className="font-label text-[10px] uppercase tracking-[0.2em] text-error block mb-6">
-              Authentication Error
-            </span>
-
-            <h1 className="text-5xl sm:text-7xl lg:text-8xl font-extrabold leading-none tracking-tighter text-on-surface font-headline mb-8">
-              {title}
-            </h1>
-
-            <p className="text-on-surface-variant text-lg leading-relaxed max-w-lg mx-auto mb-12">
-              {description}
-            </p>
-
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-              <Link
-                href="/api/auth/login"
-                className="inline-flex items-center gap-3 bg-primary text-on-primary px-8 py-4 font-headline font-bold text-sm tracking-wide transition-all active:scale-95"
-              >
-                TRY AGAIN
-              </Link>
-              <Link
-                href="/"
-                className="inline-flex items-center gap-3 ghost-border bg-white/5 hover:bg-white/10 text-on-surface px-8 py-4 font-headline font-bold text-sm tracking-wide transition-all active:scale-95"
-              >
-                <ArrowLeft className="size-4" />
-                BACK TO HOME
-              </Link>
-            </div>
-
-            <p className="mt-16 font-label text-[10px] uppercase tracking-[0.2em] text-on-surface-variant">
-              If this keeps happening, please contact the administrator.
-            </p>
-          </>
-        )}
+              <p className="mt-16 font-label text-[10px] uppercase tracking-[0.2em] text-on-surface-variant">
+                If this keeps happening, please contact the administrator.
+              </p>
+            </>
+          )}
         </div>
       </main>
 

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { cookies } from "next/headers";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/client/components/ui/button";
+import { Logo } from "@/client/components/ui/logo";
 import { SPOTIFY_COOKIE_KEYS } from "@/server/lib/spotify";
 
 export default async function NotFound() {
@@ -9,75 +10,62 @@ export default async function NotFound() {
   const isAuthenticated = cookieStore.has(SPOTIFY_COOKIE_KEYS.refreshToken);
 
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center px-6 lg:px-16 relative overflow-hidden">
+    <div className="min-h-screen bg-background flex flex-col relative overflow-hidden">
       {/* Background glow */}
       <div className="absolute top-0 left-0 w-full h-full opacity-5 pointer-events-none">
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-primary rounded-full blur-[160px]" />
       </div>
 
-      <div className="relative z-10 w-full max-w-7xl flex flex-col md:flex-row items-baseline justify-between gap-12">
-        {/* 404 number */}
-        <div className="flex flex-col">
-          <span className="font-label text-xs uppercase tracking-[0.2em] text-on-surface-variant mb-4">
-            Error Code
-          </span>
-          <h1 className="text-[8rem] md:text-[18rem] font-extrabold leading-none tracking-tighter text-on-surface flex items-start font-headline">
-            404
-            <span className="text-primary text-4xl mt-12">.</span>
-          </h1>
-        </div>
+      <main className="relative z-10 flex-1 flex items-center justify-center px-6 lg:px-16 py-16">
+        <div className="w-full max-w-7xl flex flex-col md:flex-row items-baseline justify-between gap-12">
+          {/* 404 number */}
+          <div className="flex flex-col">
+            <span className="font-label text-xs uppercase tracking-[0.2em] text-on-surface-variant mb-4">
+              Error Code
+            </span>
+            <h1 className="text-[8rem] md:text-[18rem] font-extrabold leading-none tracking-tighter text-on-surface flex items-start font-headline">
+              404
+              <span className="text-primary text-4xl mt-12">.</span>
+            </h1>
+          </div>
 
-        {/* Message & CTA */}
-        <div className="flex flex-col items-start md:items-end text-left md:text-right max-w-md">
-          <span className="font-label text-xs uppercase tracking-[0.2em] text-primary mb-8">
-            System Notification
-          </span>
-          <h2 className="text-4xl md:text-5xl font-bold text-on-surface mb-6 leading-tight font-headline">
-            The beat has dropped.
-          </h2>
-          <p className="text-on-surface-variant text-lg leading-relaxed mb-12">
-            The archival record you are looking for has been moved or purged
-            from the database. It exists now only in the silence between tracks.
-          </p>
-          <Button asChild size="lg">
-            <Link
-              href={isAuthenticated ? "/dashboard" : "/"}
-              className="flex items-center gap-3"
-            >
-              {isAuthenticated ? "RETURN TO DASHBOARD" : "RETURN HOME"}
-              <ArrowRight className="size-4" />
-            </Link>
-          </Button>
-          <div className="mt-16 flex flex-col items-start md:items-end gap-2">
-            <span className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface-variant">
-              Request ID
+          {/* Message & CTA */}
+          <div className="flex flex-col items-start md:items-end text-left md:text-right max-w-md">
+            <span className="font-label text-xs uppercase tracking-[0.2em] text-primary mb-8">
+              System Notification
             </span>
-            <span className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface">
-              STF-09X-ARCHIVE-ERR
-            </span>
+            <h2 className="text-4xl md:text-5xl font-bold text-on-surface mb-6 leading-tight font-headline">
+              The beat has dropped.
+            </h2>
+            <p className="text-on-surface-variant text-lg leading-relaxed mb-12">
+              The archival record you are looking for has been moved or purged
+              from the database. It exists now only in the silence between
+              tracks.
+            </p>
+            <Button asChild size="lg">
+              <Link
+                href={isAuthenticated ? "/dashboard" : "/"}
+                className="flex items-center gap-3"
+              >
+                {isAuthenticated ? "RETURN TO DASHBOARD" : "RETURN HOME"}
+                <ArrowRight className="size-4" />
+              </Link>
+            </Button>
+            <div className="mt-16 flex flex-col items-start md:items-end gap-2">
+              <span className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface-variant">
+                Request ID
+              </span>
+              <span className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface">
+                STF-09X-ARCHIVE-ERR
+              </span>
+            </div>
           </div>
         </div>
-      </div>
+      </main>
 
-      {/* Bottom branding */}
-      <div className="fixed bottom-12 left-6 right-6 lg:left-16 lg:right-16 flex justify-between items-end border-t border-divider pt-8">
-        <div className="flex flex-col gap-1">
-          <span className="text-xl font-bold tracking-tighter text-on-surface font-headline">
-            STATIFY
-          </span>
-          <span className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface-variant">
-            The Digital Archivist
-          </span>
-        </div>
-        <nav className="flex gap-8">
-          <span className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface-variant">
-            Support
-          </span>
-          <span className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface-variant">
-            API Status
-          </span>
-        </nav>
-      </div>
-    </main>
+      <footer className="relative z-10 w-full border-t border-divider px-6 lg:px-12 py-4 flex items-center justify-center">
+        <Logo />
+      </footer>
+    </div>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { cookies } from "next/headers";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/client/components/ui/button";
-import { Logo } from "@/client/components/ui/logo";
+import { ErrorPageFooter } from "@/client/components/app-shell/ErrorPageFooter";
 import { SPOTIFY_COOKIE_KEYS } from "@/server/lib/spotify";
 
 export default async function NotFound() {
@@ -63,9 +63,7 @@ export default async function NotFound() {
         </div>
       </main>
 
-      <footer className="relative z-10 w-full border-t border-divider px-6 lg:px-12 py-4 flex items-center justify-center">
-        <Logo />
-      </footer>
+      <ErrorPageFooter />
     </div>
   );
 }

--- a/client/components/app-shell/ErrorPageFooter.tsx
+++ b/client/components/app-shell/ErrorPageFooter.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { Logo } from "@/client/components/ui/logo";
+
+export function ErrorPageFooter() {
+  return (
+    <footer className="relative z-10 w-full border-t border-divider px-6 lg:px-12 py-4 flex flex-col md:flex-row items-center justify-between gap-4">
+      <Logo />
+      <div className="flex gap-4">
+        <Link
+          href="/privacy"
+          className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          Privacy
+        </Link>
+        <Link
+          href="/terms"
+          className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          Terms
+        </Link>
+        <a
+          href="https://developer.spotify.com/documentation/web-api"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-label text-[10px] uppercase tracking-[0.1em] text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          API
+        </a>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

- Fixes the 404 (`not-found.tsx`) footer which had `fixed bottom-12` positioning causing it to overlap content on mobile — replaced with the same flex-col layout used on the auth-error page
- Removes "The Digital Archivist" / fake "Support" + "API Status" labels from the 404 footer
- Extracts a shared `ErrorPageFooter` component used by both auth-error and 404 pages: Logo (STATIFY v2.0) on the left, Privacy / Terms / API links on the right
- Fixes Prettier formatting on auth-error page

## Test plan

- [ ] Visit a non-existent route (e.g. `/foo`) on mobile — footer sits at bottom, no overlap
- [ ] Visit `/auth-error` on mobile — same
- [ ] Both pages show Privacy, Terms, and API links in the footer on mobile and desktop

https://claude.ai/code/session_01FowxyDcCPTUd6dw1rsLr94