### PR TITLE
Fix descender clipping on now playing track title

### DIFF
--- a/client/components/dashboard/NowPlayingHero.tsx
+++ b/client/components/dashboard/NowPlayingHero.tsx
@@ -44,7 +44,7 @@ export function NowPlayingHero({
             <span className="font-label text-xs uppercase tracking-[0.2em] text-primary">
               Now Playing
             </span>
-            <h2 className="text-3xl lg:text-5xl font-bold tracking-tighter leading-none text-on-surface font-headline line-clamp-2">
+            <h2 className="text-3xl lg:text-5xl font-bold tracking-tighter leading-tight text-on-surface font-headline line-clamp-2">
               {nowPlayingTrack.name}
             </h2>
             <p className="text-xl lg:text-2xl font-light text-on-surface-variant tracking-wide truncate">


### PR DESCRIPTION
## Summary

- `leading-none` (`line-height: 1`) was clipping descenders (g, p, y, j) in the now playing track title on mobile
- Changed to `leading-tight` (`line-height: 1.25`) to give glyphs room

https://claude.ai/code/session_01FowxyDcCPTUd6dw1rsLr94