### PR TITLE
feat: add top track play button to #1 featured artist

### DIFF
--- a/app/api/artists/[id]/top-tracks/route.ts
+++ b/app/api/artists/[id]/top-tracks/route.ts
@@ -6,7 +6,10 @@ export const GET = withSpotifyAuth(async (accessToken, _request, context) => {
   const { id } = await context.params;
 
   if (!id) {
-    return NextResponse.json({ message: "Artist ID required" }, { status: 400 });
+    return NextResponse.json(
+      { message: "Artist ID required" },
+      { status: 400 },
+    );
   }
 
   const response = await getArtistTopTracks(accessToken, id);

--- a/app/api/artists/[id]/top-tracks/route.ts
+++ b/app/api/artists/[id]/top-tracks/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { withSpotifyAuth } from "@/server/lib/route-handler";
+import { getArtistTopTracks } from "@/server/services/spotify-data-service";
+
+export const GET = withSpotifyAuth(async (accessToken, _request, context) => {
+  const { id } = await context.params;
+
+  if (!id) {
+    return NextResponse.json({ message: "Artist ID required" }, { status: 400 });
+  }
+
+  const response = await getArtistTopTracks(accessToken, id);
+  return NextResponse.json(response);
+}, "Failed to load artist top tracks");

--- a/client/components/top/FeaturedArtist.tsx
+++ b/client/components/top/FeaturedArtist.tsx
@@ -1,8 +1,13 @@
+"use client";
+
 import Image from "next/image";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, Play } from "lucide-react";
 import type { SpotifyArtist } from "@/types/spotify";
+import { useArtistTopTrack } from "@/client/hooks/use-artist-top-track";
 
 export function FeaturedArtist({ artist }: { artist: SpotifyArtist }) {
+  const { topTrack } = useArtistTopTrack(artist.id);
+
   return (
     <div className="relative w-full h-[300px] lg:h-[500px] overflow-hidden bg-surface-container-lowest group cursor-pointer">
       {artist.images[0] && (
@@ -49,12 +54,43 @@ export function FeaturedArtist({ artist }: { artist: SpotifyArtist }) {
               </span>
             ))}
           </div>
+          {topTrack && (
+            <a
+              href={topTrack.external_urls.spotify}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 lg:mt-5 inline-flex items-center gap-3 bg-black/40 backdrop-blur-sm ghost-border px-3 py-2 hover:bg-white/5 transition-colors group/track"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {topTrack.album.images[0] && (
+                <Image
+                  src={topTrack.album.images[0].url}
+                  alt={topTrack.album.name}
+                  width={36}
+                  height={36}
+                  className="rounded object-cover flex-shrink-0"
+                />
+              )}
+              <div className="min-w-0">
+                <p className="text-[9px] font-label uppercase tracking-widest text-on-surface-variant">
+                  Top Track
+                </p>
+                <p className="text-sm font-semibold text-on-surface truncate max-w-[160px] lg:max-w-[260px]">
+                  {topTrack.name}
+                </p>
+              </div>
+              <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center flex-shrink-0 ml-1 group-hover/track:scale-110 transition-transform shadow-[0_0_16px_rgba(29,185,84,0.4)]">
+                <Play className="size-3.5 text-on-primary fill-current ml-0.5" />
+              </div>
+            </a>
+          )}
         </div>
         <a
           href={artist.external_urls.spotify}
           target="_blank"
           rel="noopener noreferrer"
           className="w-12 h-12 lg:w-16 lg:h-16 rounded-full bg-primary flex items-center justify-center hover:scale-110 transition-transform shadow-[0_0_30px_rgba(29,185,84,0.3)] flex-shrink-0"
+          onClick={(e) => e.stopPropagation()}
         >
           <ArrowUpRight className="size-6 lg:size-8 text-on-primary" />
         </a>

--- a/client/hooks/use-artist-top-track.ts
+++ b/client/hooks/use-artist-top-track.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import useSWR from "swr";
+import { fetchArtistTopTracks } from "@/client/services/artist-service";
+import type { SpotifyTrack } from "@/types/spotify";
+
+export function useArtistTopTrack(artistId: string) {
+  const { data, isLoading } = useSWR<{ tracks: SpotifyTrack[] }>(
+    ["artist-top-tracks", artistId],
+    () => fetchArtistTopTracks(artistId),
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  return {
+    topTrack: data?.tracks?.[0] ?? null,
+    isLoading,
+  };
+}

--- a/client/services/artist-service.ts
+++ b/client/services/artist-service.ts
@@ -1,0 +1,8 @@
+import type { SpotifyArtistTopTracksResponse } from "@/types/spotify";
+import { fetchJson } from "@/client/services/fetcher";
+
+export async function fetchArtistTopTracks(artistId: string) {
+  return fetchJson<SpotifyArtistTopTracksResponse>(
+    `/api/artists/${artistId}/top-tracks`,
+  );
+}

--- a/server/services/spotify-data-service.ts
+++ b/server/services/spotify-data-service.ts
@@ -1,6 +1,7 @@
 import { spotifyWebApiFetch } from "@/server/adapters/spotify/web-api-adapter";
 import type {
   SpotifyArtist,
+  SpotifyArtistTopTracksResponse,
   SpotifyCurrentlyPlaying,
   SpotifyRecentlyPlayedResponse,
   SpotifyTimeRange,
@@ -59,6 +60,16 @@ export async function getSpotifyTopItems(
       time_range: timeRange,
       limit,
     },
+  );
+}
+
+export async function getArtistTopTracks(
+  accessToken: string,
+  artistId: string,
+) {
+  return spotifyWebApiFetch<SpotifyArtistTopTracksResponse>(
+    `/artists/${artistId}/top-tracks`,
+    accessToken,
   );
 }
 

--- a/types/spotify.ts
+++ b/types/spotify.ts
@@ -75,3 +75,7 @@ export interface SpotifyTopResponse<T> {
   limit: number;
   offset: number;
 }
+
+export interface SpotifyArtistTopTracksResponse {
+  tracks: SpotifyTrack[];
+}


### PR DESCRIPTION
## Summary

- Adds a new `/api/artists/[id]/top-tracks` endpoint that fetches the artist's top tracks from Spotify
- Renders a clickable "Top Track" strip on the #1 `FeaturedArtist` hero card — album art, track name, and a Spotify-green play button that opens the track directly in Spotify
- The existing `ArrowUpRight` button remains to navigate to the artist's Spotify profile page

## Changes

- `types/spotify.ts` — added `SpotifyArtistTopTracksResponse`
- `server/services/spotify-data-service.ts` — added `getArtistTopTracks`
- `app/api/artists/[id]/top-tracks/route.ts` — new API route (auth-gated via `withSpotifyAuth`)
- `client/services/artist-service.ts` — client fetch wrapper
- `client/hooks/use-artist-top-track.ts` — SWR hook returning the artist's #1 track
- `client/components/top/FeaturedArtist.tsx` — converted to `"use client"`, fetches and renders top track strip

## Test plan

- [ ] Visit `/artists` while logged in
- [ ] Confirm the #1 featured artist card shows a "Top Track" strip below the genre tags
- [ ] Clicking the play button opens the track in Spotify (new tab)
- [ ] Clicking the `ArrowUpRight` button opens the artist profile in Spotify (new tab)
- [ ] Strip does not appear while loading or if the API returns no tracks

https://claude.ai/code/session_01KmBA3fkihdEK2NVbhfgJPj