### PR TITLE
fix: show skeleton in top track strip while artist track is loading

### DIFF
--- a/client/components/top/FeaturedArtist.tsx
+++ b/client/components/top/FeaturedArtist.tsx
@@ -4,9 +4,10 @@ import Image from "next/image";
 import { ArrowUpRight, Play } from "lucide-react";
 import type { SpotifyArtist } from "@/types/spotify";
 import { useArtistTopTrack } from "@/client/hooks/use-artist-top-track";
+import { Skeleton } from "@/client/components/ui/skeleton";
 
 export function FeaturedArtist({ artist }: { artist: SpotifyArtist }) {
-  const { topTrack } = useArtistTopTrack(artist.id);
+  const { topTrack, isLoading } = useArtistTopTrack(artist.id);
 
   return (
     <div className="relative w-full h-[300px] lg:h-[500px] overflow-hidden bg-surface-container-lowest group cursor-pointer">
@@ -54,36 +55,48 @@ export function FeaturedArtist({ artist }: { artist: SpotifyArtist }) {
               </span>
             ))}
           </div>
-          {topTrack && (
-            <a
-              href={topTrack.external_urls.spotify}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-4 lg:mt-5 inline-flex items-center gap-3 bg-black/40 backdrop-blur-sm ghost-border px-3 py-2 hover:bg-white/5 transition-colors group/track"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {topTrack.album.images[0] && (
-                <Image
-                  src={topTrack.album.images[0].url}
-                  alt={topTrack.album.name}
-                  width={36}
-                  height={36}
-                  className="rounded object-cover flex-shrink-0"
-                />
-              )}
-              <div className="min-w-0">
-                <p className="text-[9px] font-label uppercase tracking-widest text-on-surface-variant">
-                  Top Track
-                </p>
-                <p className="text-sm font-semibold text-on-surface truncate max-w-[160px] lg:max-w-[260px]">
-                  {topTrack.name}
-                </p>
+          {/* Always reserve space for the top track strip to prevent layout shift */}
+          <div className="mt-4 lg:mt-5">
+            {isLoading ? (
+              <div className="inline-flex items-center gap-3 bg-black/40 backdrop-blur-sm ghost-border px-3 py-2">
+                <Skeleton className="w-9 h-9 rounded flex-shrink-0" />
+                <div className="space-y-1.5">
+                  <Skeleton className="h-2 w-14" />
+                  <Skeleton className="h-3 w-36" />
+                </div>
+                <Skeleton className="w-7 h-7 rounded-full flex-shrink-0 ml-1" />
               </div>
-              <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center flex-shrink-0 ml-1 group-hover/track:scale-110 transition-transform shadow-[0_0_16px_rgba(29,185,84,0.4)]">
-                <Play className="size-3.5 text-on-primary fill-current ml-0.5" />
-              </div>
-            </a>
-          )}
+            ) : topTrack ? (
+              <a
+                href={topTrack.external_urls.spotify}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-3 bg-black/40 backdrop-blur-sm ghost-border px-3 py-2 hover:bg-white/5 transition-colors group/track"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {topTrack.album.images[0] && (
+                  <Image
+                    src={topTrack.album.images[0].url}
+                    alt={topTrack.album.name}
+                    width={36}
+                    height={36}
+                    className="rounded object-cover flex-shrink-0"
+                  />
+                )}
+                <div className="min-w-0">
+                  <p className="text-[9px] font-label uppercase tracking-widest text-on-surface-variant">
+                    Top Track
+                  </p>
+                  <p className="text-sm font-semibold text-on-surface truncate max-w-[160px] lg:max-w-[260px]">
+                    {topTrack.name}
+                  </p>
+                </div>
+                <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center flex-shrink-0 ml-1 group-hover/track:scale-110 transition-transform shadow-[0_0_16px_rgba(29,185,84,0.4)]">
+                  <Play className="size-3.5 text-on-primary fill-current ml-0.5" />
+                </div>
+              </a>
+            ) : null}
+          </div>
         </div>
         <a
           href={artist.external_urls.spotify}


### PR DESCRIPTION
## Summary

Fixes the layout shift on the #1 featured artist card where the top track strip pops in after the artist name/genres have already rendered.

Instead of conditionally mounting the strip only when data arrives, the strip container is always present — showing an inline skeleton (album thumbnail rect + label lines + play circle) while `isLoading` is true, then swapping to the real content once the fetch resolves.

## Test plan

- [ ] Visit `/artists` — the track strip skeleton should be visible immediately alongside the artist name, with no jump when the real track loads

https://claude.ai/code/session_01KmBA3fkihdEK2NVbhfgJPj