### PR TITLE
fix: constrain top track skeleton width on mobile in FeaturedArtist

### DIFF
--- a/client/components/top/FeaturedArtist.tsx
+++ b/client/components/top/FeaturedArtist.tsx
@@ -58,11 +58,11 @@ export function FeaturedArtist({ artist }: { artist: SpotifyArtist }) {
           {/* Always reserve space for the top track strip to prevent layout shift */}
           <div className="mt-4 lg:mt-5">
             {isLoading ? (
-              <div className="inline-flex items-center gap-3 bg-black/40 backdrop-blur-sm ghost-border px-3 py-2">
+              <div className="inline-flex items-center gap-3 bg-black/40 backdrop-blur-sm ghost-border px-3 py-2 max-w-full overflow-hidden">
                 <Skeleton className="w-9 h-9 rounded flex-shrink-0" />
-                <div className="space-y-1.5">
+                <div className="flex-1 min-w-0 space-y-1.5">
                   <Skeleton className="h-2 w-14" />
-                  <Skeleton className="h-3 w-36" />
+                  <Skeleton className="h-3 w-24 lg:w-36" />
                 </div>
                 <Skeleton className="w-7 h-7 rounded-full flex-shrink-0 ml-1" />
               </div>


### PR DESCRIPTION
## Summary

The top track skeleton strip in `FeaturedArtist` was overflowing on mobile because the `inline-flex` container had no width constraint and the track name skeleton was a fixed `w-36` (144px).

- Added `max-w-full overflow-hidden` to the skeleton container so it never exceeds the parent width
- Changed the text div to `flex-1 min-w-0` so it can shrink in the flex layout
- Reduced track name skeleton to `w-24` on mobile, `lg:w-36` on desktop

Mirrors the same `max-w-full overflow-hidden` / `flex-1 min-w-0` treatment already applied to the live track strip.

## Test plan

- [ ] View `/artists` on a mobile viewport while data loads — skeleton strip should fit within the hero card without overflowing

https://claude.ai/code/session_01KmBA3fkihdEK2NVbhfgJPj