### PR TITLE
fix: use theme-aware surface tokens on top track strip for light mode

### DIFF
--- a/client/components/top/FeaturedArtist.tsx
+++ b/client/components/top/FeaturedArtist.tsx
@@ -58,7 +58,7 @@ export function FeaturedArtist({ artist }: { artist: SpotifyArtist }) {
           {/* Always reserve space for the top track strip to prevent layout shift */}
           <div className="mt-4 lg:mt-5">
             {isLoading ? (
-              <div className="inline-flex items-center gap-3 bg-black/40 backdrop-blur-sm ghost-border px-3 py-2 max-w-full overflow-hidden">
+              <div className="inline-flex items-center gap-3 bg-surface-container/80 backdrop-blur-sm ghost-border px-3 py-2 max-w-full overflow-hidden">
                 <Skeleton className="w-9 h-9 rounded flex-shrink-0" />
                 <div className="flex-1 min-w-0 space-y-1.5">
                   <Skeleton className="h-2 w-14" />
@@ -71,7 +71,7 @@ export function FeaturedArtist({ artist }: { artist: SpotifyArtist }) {
                 href={topTrack.external_urls.spotify}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-3 bg-black/40 backdrop-blur-sm ghost-border px-3 py-2 hover:bg-white/5 transition-colors group/track"
+                className="inline-flex items-center gap-3 bg-surface-container/80 backdrop-blur-sm ghost-border px-3 py-2 hover:bg-surface-container-high/60 transition-colors group/track max-w-full overflow-hidden"
                 onClick={(e) => e.stopPropagation()}
               >
                 {topTrack.album.images[0] && (
@@ -83,11 +83,11 @@ export function FeaturedArtist({ artist }: { artist: SpotifyArtist }) {
                     className="rounded object-cover flex-shrink-0"
                   />
                 )}
-                <div className="min-w-0">
-                  <p className="text-[9px] font-label uppercase tracking-widest text-on-surface-variant">
+                <div className="flex-1 min-w-0 overflow-hidden">
+                  <p className="text-[9px] font-label uppercase tracking-widest text-on-surface-variant truncate">
                     Top Track
                   </p>
-                  <p className="text-sm font-semibold text-on-surface truncate max-w-[160px] lg:max-w-[260px]">
+                  <p className="text-sm font-semibold text-on-surface truncate">
                     {topTrack.name}
                   </p>
                 </div>


### PR DESCRIPTION
## Summary

Fixes the top track strip in `FeaturedArtist` looking broken in light mode.

- `bg-black/40` → `bg-surface-container/80` — uses the CSS custom property so it's dark in dark mode and light gray in light mode
- `hover:bg-white/5` → `hover:bg-surface-container-high/60` — same treatment for the hover state
- Applied to both the loading skeleton and the live strip
- Also cleans up the live strip text container to `flex-1 min-w-0 overflow-hidden` for consistent truncation with the skeleton

## Test plan

- [ ] Toggle to light mode and visit `/artists` — strip should render as a clean light gray frosted panel, not a dark box
- [ ] Dark mode should look unchanged

https://claude.ai/code/session_01KmBA3fkihdEK2NVbhfgJPj