### PR TITLE
Fix mobile navbar hamburger icon alignment

### DIFF
--- a/client/components/landing/MobileNav.tsx
+++ b/client/components/landing/MobileNav.tsx
@@ -70,30 +70,32 @@ export function MobileNav() {
         aria-label={iconActive ? "Close menu" : "Open menu"}
       >
         <span className="relative w-6 h-5 block">
-        <span
-          className="absolute left-0 w-full h-[2px] bg-on-surface-variant group-hover:bg-on-surface transition-all duration-300 ease-in-out"
-          style={{
-            top: iconActive ? "50%" : "0",
-            transform: iconActive ? "translateY(-50%) rotate(45deg)" : "none",
-          }}
-        />
-        <span
-          className="absolute left-0 top-1/2 -translate-y-1/2 w-full h-[2px] bg-on-surface-variant group-hover:bg-on-surface transition-all duration-300 ease-in-out"
-          style={{
-            opacity: iconActive ? 0 : 1,
-            transform: iconActive
-              ? "translateY(-50%) scaleX(0)"
-              : "translateY(-50%) scaleX(1)",
-          }}
-        />
-        <span
-          className="absolute left-0 w-full h-[2px] bg-on-surface-variant group-hover:bg-on-surface transition-all duration-300 ease-in-out"
-          style={{
-            bottom: iconActive ? "auto" : "0",
-            top: iconActive ? "50%" : "auto",
-            transform: iconActive ? "translateY(-50%) rotate(-45deg)" : "none",
-          }}
-        />
+          <span
+            className="absolute left-0 w-full h-[2px] bg-on-surface-variant group-hover:bg-on-surface transition-all duration-300 ease-in-out"
+            style={{
+              top: iconActive ? "50%" : "0",
+              transform: iconActive ? "translateY(-50%) rotate(45deg)" : "none",
+            }}
+          />
+          <span
+            className="absolute left-0 top-1/2 -translate-y-1/2 w-full h-[2px] bg-on-surface-variant group-hover:bg-on-surface transition-all duration-300 ease-in-out"
+            style={{
+              opacity: iconActive ? 0 : 1,
+              transform: iconActive
+                ? "translateY(-50%) scaleX(0)"
+                : "translateY(-50%) scaleX(1)",
+            }}
+          />
+          <span
+            className="absolute left-0 w-full h-[2px] bg-on-surface-variant group-hover:bg-on-surface transition-all duration-300 ease-in-out"
+            style={{
+              bottom: iconActive ? "auto" : "0",
+              top: iconActive ? "50%" : "auto",
+              transform: iconActive
+                ? "translateY(-50%) rotate(-45deg)"
+                : "none",
+            }}
+          />
         </span>
       </button>
 

--- a/client/components/landing/MobileNav.tsx
+++ b/client/components/landing/MobileNav.tsx
@@ -65,10 +65,11 @@ export function MobileNav() {
     <>
       <button
         ref={buttonRef}
-        className="md:hidden relative w-6 h-5 cursor-pointer group"
+        className="md:hidden relative min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer group"
         onClick={iconActive ? handleClose : handleOpen}
         aria-label={iconActive ? "Close menu" : "Open menu"}
       >
+        <span className="relative w-6 h-5 block">
         <span
           className="absolute left-0 w-full h-[2px] bg-on-surface-variant group-hover:bg-on-surface transition-all duration-300 ease-in-out"
           style={{
@@ -93,6 +94,7 @@ export function MobileNav() {
             transform: iconActive ? "translateY(-50%) rotate(-45deg)" : "none",
           }}
         />
+        </span>
       </button>
 
       {overlayMounted &&


### PR DESCRIPTION
## Summary

- Give the `MobileNav` hamburger button `min-h-[44px] min-w-[44px] flex items-center justify-center` to match the sizing of `ThemeToggle` and `LogoutButton`
- Wrap the hamburger line spans in a positioned inner `<span className="relative w-6 h-5 block">` so the icon renders correctly within the larger touch target
- Fixes vertical misalignment between the hamburger and the right-side icon buttons on both the landing page and dashboard mobile headers

## Test plan

- [ ] Open the landing page on a mobile viewport — verify the hamburger icon is vertically centered with the ThemeToggle icon
- [ ] Open the dashboard on a mobile viewport — verify the same alignment with ThemeToggle and LogoutButton
- [ ] Confirm hamburger open/close animation still works correctly

https://claude.ai/code/session_01LjFtR9ZSYKMXCt1fsqNZww